### PR TITLE
ResultOnlyMode: Added logLevel.RESULT & env to filter the output

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,5 @@ ANTHROPIC_API_KEY=
 # Set to false to disable anonymized telemetry
 ANONYMIZED_TELEMETRY=true
 
-# Set to true to enable verbose logging
-BROWSER_USE_DEBUG_LOGGING=true
+# LogLevel: Set to debug to enable verbose logging, set to result to get results only. Available: result | debug | info
+BROWSER_USE_LOGGING_LEVEL=info

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -123,6 +123,8 @@ class Agent:
 			result = self.controller.act(model_output.action)
 			if result.extracted_content:
 				logger.info(f'📄 Result: {result.extracted_content}')
+			if result.is_done:
+				logger.result(f'{result.extracted_content}')
 			self.consecutive_failures = 0
 
 		except Exception as e:

--- a/browser_use/logging_config.py
+++ b/browser_use/logging_config.py
@@ -2,9 +2,59 @@ import logging
 import os
 import sys
 
+def addLoggingLevel(levelName, levelNum, methodName=None):
+    """
+    Comprehensively adds a new logging level to the `logging` module and the
+    currently configured logging class.
+
+    `levelName` becomes an attribute of the `logging` module with the value
+    `levelNum`. `methodName` becomes a convenience method for both `logging`
+    itself and the class returned by `logging.getLoggerClass()` (usually just
+    `logging.Logger`). If `methodName` is not specified, `levelName.lower()` is
+    used.
+
+    To avoid accidental clobberings of existing attributes, this method will
+    raise an `AttributeError` if the level name is already an attribute of the
+    `logging` module or if the method name is already present
+
+    Example
+    -------
+    >>> addLoggingLevel('TRACE', logging.DEBUG - 5)
+    >>> logging.getLogger(__name__).setLevel("TRACE")
+    >>> logging.getLogger(__name__).trace('that worked')
+    >>> logging.trace('so did this')
+    >>> logging.TRACE
+    5
+
+    """
+    if not methodName:
+        methodName = levelName.lower()
+
+    if hasattr(logging, levelName):
+       raise AttributeError('{} already defined in logging module'.format(levelName))
+    if hasattr(logging, methodName):
+       raise AttributeError('{} already defined in logging module'.format(methodName))
+    if hasattr(logging.getLoggerClass(), methodName):
+       raise AttributeError('{} already defined in logger class'.format(methodName))
+
+    # This method was inspired by the answers to Stack Overflow post
+    # http://stackoverflow.com/q/2183233/2988730, especially
+    # http://stackoverflow.com/a/13638084/2988730
+    def logForLevel(self, message, *args, **kwargs):
+        if self.isEnabledFor(levelNum):
+            self._log(levelNum, message, args, **kwargs)
+    def logToRoot(message, *args, **kwargs):
+        logging.log(levelNum, message, *args, **kwargs)
+
+    logging.addLevelName(levelNum, levelName)
+    setattr(logging, levelName, levelNum)
+    setattr(logging.getLoggerClass(), methodName, logForLevel)
+    setattr(logging, methodName, logToRoot)
 
 def setup_logging():
-	debug_logging = os.getenv('BROWSER_USE_DEBUG_LOGGING', 'false').lower() == 'true'
+	addLoggingLevel("RESULT", 35) #This allows ERROR, FATAL and CRITICAL
+
+	log_type = os.getenv('BROWSER_USE_LOGGING_LEVEL', 'result')
 
 	# Check if handlers are already set up
 	if logging.getLogger().hasHandlers():
@@ -22,12 +72,21 @@ def setup_logging():
 
 	# Setup single handler for all loggers
 	console = logging.StreamHandler(sys.stdout)
-	console.setFormatter(BrowserUseFormatter('%(levelname)-8s [%(name)s] %(message)s'))
+
+	# adittional setLevel here to filter logs
+	if log_type == 'result':
+		console.setLevel("RESULT")
+		console.setFormatter(BrowserUseFormatter('%(message)s'))
+	else:
+		console.setFormatter(BrowserUseFormatter('%(levelname)-8s [%(name)s] %(message)s'))
 
 	# Configure root logger only
 	root.addHandler(console)
 
-	if debug_logging:
+	# switch cases for log_type
+	if log_type == 'result':
+		root.setLevel("RESULT") # string usage to avoid syntax error
+	elif log_type == 'debug':
 		root.setLevel(logging.DEBUG)
 	else:
 		root.setLevel(logging.INFO)

--- a/browser_use/telemetry/service.py
+++ b/browser_use/telemetry/service.py
@@ -34,7 +34,7 @@ class ProductTelemetry:
 
 	def __init__(self) -> None:
 		telemetry_disabled = os.getenv('ANONYMIZED_TELEMETRY', 'true').lower() == 'false'
-		self.debug_logging = os.getenv('BROWSER_USE_DEBUG_LOGGING', 'false').lower() == 'true'
+		self.debug_logging = os.getenv('BROWSER_USE_LOGGING_LEVEL', 'info').lower() == 'debug'
 
 		if telemetry_disabled:
 			self._posthog_client = None


### PR DESCRIPTION
### browser-use can now be run in "result only" mode to give back only the result info or state at the end of the run.

LogLevel: Set to debug to enable verbose logging, set to result to get results only. Available: result | debug | info
BROWSER_USE_LOGGING_LEVEL=result

```
python examples/hugging_face.py
Top 5 models with cc-by-sa-4.0 license have been saved successfully.
```