### PR TITLE
Allow headless option when initializing controller

### DIFF
--- a/browser_use/controller/service.py
+++ b/browser_use/controller/service.py
@@ -25,8 +25,8 @@ logger = logging.getLogger(__name__)
 
 
 class Controller:
-	def __init__(self, keep_open: bool = False):
-		self.browser = Browser(keep_open=keep_open)
+	def __init__(self, headless: bool = False, keep_open: bool = False):
+		self.browser = Browser(headless=headless, keep_open=keep_open)
 		self.registry = Registry()
 		self._register_default_actions()
 


### PR DESCRIPTION
Simple change: allow headless option by making it an optional argument to the Controller class. Headless option is already implemented in the Browser class, so all we have to do is pass that down.