### PR TITLE
Fix/step exception

### DIFF
--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -137,8 +137,6 @@ class Agent:
 			result = self._handle_step_error(e)
 			self._last_result = result
 
-			model_output = None
-
 			if result.error:
 				self.telemetry.capture(
 					AgentStepErrorTelemetryEvent(
@@ -146,8 +144,10 @@ class Agent:
 						error=result.error,
 					)
 				)
-		if state:
-			self._make_history_item(model_output, state, result)
+			model_output = None
+		finally:
+			if state:
+				self._make_history_item(model_output, state, result)
 
 	def _handle_step_error(self, error: Exception) -> ActionResult:
 		"""Handle all types of errors that can occur during a step"""

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -136,6 +136,9 @@ class Agent:
 		except Exception as e:
 			result = self._handle_step_error(e)
 			self._last_result = result
+
+			model_output = None
+
 			if result.error:
 				self.telemetry.capture(
 					AgentStepErrorTelemetryEvent(
@@ -143,10 +146,8 @@ class Agent:
 						error=result.error,
 					)
 				)
-			model_output = None
-		finally:
-			if state:
-				self._make_history_item(model_output, state, result)
+		if state:
+			self._make_history_item(model_output, state, result)
 
 	def _handle_step_error(self, error: Exception) -> ActionResult:
 		"""Handle all types of errors that can occur during a step"""

--- a/browser_use/agent/service.py
+++ b/browser_use/agent/service.py
@@ -136,9 +136,6 @@ class Agent:
 		except Exception as e:
 			result = self._handle_step_error(e)
 			self._last_result = result
-
-			model_output = None
-
 			if result.error:
 				self.telemetry.capture(
 					AgentStepErrorTelemetryEvent(
@@ -146,8 +143,10 @@ class Agent:
 						error=result.error,
 					)
 				)
-		if state:
-			self._make_history_item(model_output, state, result)
+			model_output = None
+		finally:
+			if state:
+				self._make_history_item(model_output, state, result)
 
 	def _handle_step_error(self, error: Exception) -> ActionResult:
 		"""Handle all types of errors that can occur during a step"""


### PR DESCRIPTION
I found a bug with the error handling inside the step of the agent: 
1. There was n "finally" - making the handling less robust so sometimes the line `self._make_history_item(model_output, state, result)` is not called. 
2. Moving `model_output = None` to the last line makes sure that the `finally` block is called.

Other than that, it shouldn't affect the code 