### PR TITLE
Added optional proxy to Browser

### DIFF
--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -5,7 +5,9 @@ Playwright browser on steroids.
 import asyncio
 import logging
 from dataclasses import dataclass, field
-
+from typing import Optional
+from playwright._impl._api_structures import ProxySettings
+    
 from playwright.async_api import Browser as PlaywrightBrowser
 from playwright.async_api import (
 	Playwright,
@@ -41,6 +43,7 @@ class BrowserConfig:
 	extra_chromium_args: list[str] = field(default_factory=list)
 	wss_url: str | None = None
 
+	proxy: Optional[ProxySettings] = field(default=None)
 	new_context_config: BrowserContextConfig = field(default_factory=BrowserContextConfig)
 
 
@@ -121,6 +124,7 @@ class Browser:
 					]
 					+ disable_security_args
 					+ self.config.extra_chromium_args,
+					proxy=self.config.proxy
 				)
 
 				return browser

--- a/browser_use/browser/browser.py
+++ b/browser_use/browser/browser.py
@@ -5,7 +5,6 @@ Playwright browser on steroids.
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Optional
 from playwright._impl._api_structures import ProxySettings
     
 from playwright.async_api import Browser as PlaywrightBrowser
@@ -43,7 +42,7 @@ class BrowserConfig:
 	extra_chromium_args: list[str] = field(default_factory=list)
 	wss_url: str | None = None
 
-	proxy: Optional[ProxySettings] = field(default=None)
+	proxy: ProxySettings | None = field(default=None)
 	new_context_config: BrowserContextConfig = field(default_factory=BrowserContextConfig)
 
 


### PR DESCRIPTION
Added a new feature for Issue #88 : optional proxy to Browser

I was just using the playwrite `proxy` option so the solution is native and supported by the framework. 

### Usage Example: 

``` python
from browser_use import Browser, BrowserConfig
from playwright._impl._api_structures import ProxySettings

browser_use_browser = Browser(
    config=BrowserConfig(
        headless=False,
        proxy=ProxySettings(
                server="http://localhost:8080",  # Replace with your server
            ),
    )
)
```


Works perfectly.


 